### PR TITLE
feat: allow blocks re-enqueue on module parsing failed

### DIFF
--- a/.docs/config.md
+++ b/.docs/config.md
@@ -10,35 +10,28 @@ chain:
   prefix: "cosmos"
   modules:
 
-node: 
+node:
   type: remote
-  config: 
+  config:
     rpc:
       client_name: juno
       address: http://localhost:26657
       max_connections: 20
     grpc:
-      insecure: true
       address: localhost:9090
 
 parsing:
-  fast_sync: true
+  workers: 1
   listen_new_blocks: true
-  parse_genesis: true
   parse_old_blocks: true
   start_height: 1
-  workers: 1
+  parse_genesis: true
+  fast_sync: true
+  re_enqueue_when_failed: false
 
 database:
-  host: localhost
-  max_idle_connections: 0
-  max_open_connections: 0
-  name: database-name
-  password: password
-  port: 5432
-  schema: public
-  ssl_mode: 
-  user: user
+  url: postgres://user:password@localhost:5432/juno?sslmode=disable
+  partition_size: 100000
 
 logging:
   format: "text"
@@ -60,115 +53,104 @@ Let's see what each section refers to:
 ## `chain`
 This section contains the details of the chain configuration regarding the Cosmos SDK.
 
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
-| `modules` | `array` | List of modules that should be enabled | `[ "auth", "bank", "distribution" ]` |
-| `prefix` | `string` | Bech 32 prefix of the addresses | `cosmos` | 
+| Attribute |   Type   | Description                            | Example                              |
+|:---------:|:--------:|:---------------------------------------|:-------------------------------------|
+| `modules` | `array`  | List of modules that should be enabled | `[ "auth", "bank", "distribution" ]` |
+| `prefix`  | `string` | Bech 32 prefix of the addresses        | `cosmos`                             | 
 
 ### Supported modules
-Currently we support the followings Cosmos modules:
+Currently, we support the following modules:
 
-- `auth` to parse the `x/auth` data
-- `bank` to parse the `x/bank` data
-- `distribution` to parse the `x/distribution` data
-- `gov` to parse the `x/gox` data
-- `mint` to parse the `x/mint` data
-- `slashing` to parse the `x/slashing` data
-- `staking` to parse the `x/staking` data
-
-We also have the following custom modules implemented:
-
-- `modules` to get the list of enabled modules inside Juno
-- `pricefeed` to get the token prices
 - `pruning` to periodically prune the old database data
 - `telemetry` to support a telemetry service
 
 ## `node`
-This section contains the details of the node to which Juno will connect. 
+This section contains the details of the node to which Juno will connect.
 
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
-| `type` | `string` | Tells which type of node to use (either `local` or `remote`) | `remote` |
-| `config` | `object` | Contains the configuration data for the node | | 
+| Attribute |   Type   | Description                                                  | Example  |
+|:---------:|:--------:|:-------------------------------------------------------------|:---------|
+|  `type`   | `string` | Tells which type of node to use (either `local` or `remote`) | `remote` |
+| `config`  | `object` | Contains the configuration data for the node                 |          | 
 
 ### Remote node
-A remote node is the default implementation of a node. It relies on both an RPC and gRPC connections to get the data. If you want to use this kind of node, you need to set the [`node`](#node) type to `remote` and then set the following attributes of the configuration.
+A remote node is the default implementation of a node. It relies on both an RPC and gRPC connections to get the data. If
+you want to use this kind of node, you need to set the [`node`](#node) type to `remote` and then set the following
+attributes of the configuration.
 
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
-| `rpc` | `object` | Contains the RPC configuration data | | 
-| `grpc` | `object` | Contains the gRPC configuration data | | 
+| Attribute |   Type   | Description                                                                                                       | Example |
+|:---------:|:--------:|:------------------------------------------------------------------------------------------------------------------|:--------|
+|   `rpc`   | `object` | Contains the RPC configuration data                                                                               |         | 
+|  `grpc`   | `object` | (Optional) Contains the gRPC configuration data. If not provided, a gRPC-over-RPC connection will be used instead |         | 
 
 #### `rpc`
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
-| `address` | `string` | Address of the RPC endpoint | `http://localhost:26657` |
-| `client_name` | `string` | Client name used when subscribing to the Tendermint websocket | `juno` |
-| `max_connections` | `int` | Max number of connections that can created towards the RPC node (any value less or equal to `0` means to use the default one instead) | `20` | 
+
+|     Attribute     |   Type   | Description                                                                                                                           | Example                  |
+|:-----------------:|:--------:|:--------------------------------------------------------------------------------------------------------------------------------------|:-------------------------|
+|     `address`     | `string` | Address of the RPC endpoint                                                                                                           | `http://localhost:26657` |
+|   `client_name`   | `string` | Client name used when subscribing to the Tendermint websocket                                                                         | `juno`                   |
+| `max_connections` |  `int`   | Max number of connections that can created towards the RPC node (any value less or equal to `0` means to use the default one instead) | `20`                     | 
 
 #### `grpc`
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
+
+| Attribute |   Type   | Description                  | Example          |
+|:---------:|:--------:|:-----------------------------|:-----------------|
 | `address` | `string` | Address of the gRPC endpoint | `localhost:9090` |
-| `insecure` | `boolean` | Whether the gRPC endpoint is insecure or not | `false` |
 
 ### Local node
-A local node reads the data to be parsed from a local directory referred to as `home`. If you want to use this kind of node, you need to set the [`node`](#node) type to `local` and then set the following attributes of the configuration.
+A local node reads the data to be parsed from a local directory referred to as `home`. If you want to use this kind of
+node, you need to set the [`node`](#node) type to `local` and then set the following attributes of the configuration.
 
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
-| `home` | `string` | Path to the home folder of the node | `/home/user/.gaiad` |
+| Attribute |   Type   | Description                         | Example             |
+|:---------:|:--------:|:------------------------------------|:--------------------|
+|  `home`   | `string` | Path to the home folder of the node | `/home/user/.gaiad` |
 
 ## `parsing`
 
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
-| `fast_sync` | `boolean` | Whether Juno should use the fast sync abilities of different modules when enabled | `false` |
-| `listen_new_blocks` | `boolean` | Whether Juno should parse new blocks as soon as they get created | `true` | 
-| `parse_genesis` | `boolean` | Whether Juno needs to parse the genesis state or not | `true` |
-| `parse_old_blocks` | `boolean` | Whether Juno should parse old chain blocks or not | `true` | 
-| `start_height` | `integer` | Height at which Juno should start parsing old blocks | `250000` | 
-| `workers` | `integer` | Number of works that will be used to fetch the data and store it inside the database | `5` |
-| `genesis_file_path` | `string` | Path of the genesis file to be parsed | `'/bdjuno/.bdjuno/genesis/genesis.json'` |
+|        Attribute         |   Type    | Description                                                                                          | Example                                  |
+|:------------------------:|:---------:|:-----------------------------------------------------------------------------------------------------|:-----------------------------------------|
+|        `workers`         | `integer` | Number of workers that will be used to fetch the data and store it inside the database               | `5`                                      |
+|       `fast_sync`        | `boolean` | Whether Juno should use the fast sync abilities of different modules when enabled                    | `false`                                  |
+|   `listen_new_blocks`    | `boolean` | Whether Juno should parse new blocks as soon as they get created                                     | `true`                                   | 
+|     `parse_genesis`      | `boolean` | Whether Juno needs to parse the genesis state or not                                                 | `true`                                   |
+|    `parse_old_blocks`    | `boolean` | Whether Juno should parse old chain blocks or not                                                    | `true`                                   | 
+|      `start_height`      | `integer` | Height at which Juno should start parsing old blocks                                                 | `250000`                                 | 
+|   `genesis_file_path`    | `string`  | Path of the genesis file to be parsed                                                                | `'/bdjuno/.bdjuno/genesis/genesis.json'` |
+| `re_enqueue_when_failed` | `boolean` | Whether blocks should be re-enqueued if the parsing inside various modules fails. (Default: `false`) | `true`                                   |
 
 ## `database`
 This section contains all the different configuration related to the PostgreSQL database where Juno will write the data.
 
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
-| `host` | `string` | Host where the database is found | `localhost` | 
-| `port` | `integer` | Port to be used to connect to the PostgreSQL instance | `5432` |
-| `name` | `string` | Name of the database to which connect to | `juno` | 
-| `user` | `string` | Name of the user to use when connecting to the database. This user must have read/write access to all the database. | `juno` | 
-| `password` | `string` | Password to be used to connect to the database instance | `password` | 
-| `schema` | `string` | Schema to be used inside the database (default: `public`) | `public` | 
-| `ssl_mode` | `string` | [PostgreSQL SSL mode](https://www.postgresql.org/docs/9.1/libpq-ssl.html) to be used when connecting to the database. If not set, `disable` will be used. | `verify-ca` |
-| `max_idle_connections` | `integer` | Max number of idle connections that should be kept open (default: `1`) | `10` |
-| `max_open_connections` | `integer` | Max number of open connections at any time (default: `1`) | `15` |
+|    Attribute     |   Type    | Description                                                                                                                                               | Example                                                                             |
+|:----------------:|:---------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+|      `url`       | `string`  | URI used to connect to the database. (e.g. [PostgreSQL Connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS). | `postgresql://user:password@localhost:5432/juno?sslmode=disable&search_path=public` |
+| `partition_size` | `integer` | Number of rows that should be present inside each partition (used for transactions and messages).                                                         | `10000`                                                                             |
 
 ## `logging`
 This section allows to configure the logging details of Juno.
 
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
-| `format` | `string` | Format in which the logs should be output (either `json` or `text`) | `json` | 
-| `level` | `string` | Level of the log (either `verbose`, `debug`, `info`, `warn` or `error`) | `error` | 
+| Attribute |   Type   | Description                                                             | Example |
+|:---------:|:--------:|:------------------------------------------------------------------------|:--------|
+| `format`  | `string` | Format in which the logs should be output (either `json` or `text`)     | `json`  | 
+|  `level`  | `string` | Level of the log (either `verbose`, `debug`, `info`, `warn` or `error`) | `error` | 
 
 ## `pruning`
-This section contains the configuration about the pruning options of the database. Note that this will have effect only if you add the `"pruning"` entry to the `modules` field of the [`chain` config](#chain).
+This section contains the configuration about the pruning options of the database. Note that this will have effect only
+if you add the `"pruning"` entry to the `modules` field of the [`chain` config](#chain).
 
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ |
-| `interval` | `integer` | Number of blocks that should pass between one pruning and the other (default: prune every `10` blocks) | `100` | 
-| `keep_every` | `integer` | Keep the state every `nth` block, even if it should have been pruned | `500` | 
-| `keep_recent` | `integer` | Do not prune this amount of recent states | `100` |
+|   Attribute   |   Type    | Description                                                                                            | Example |
+|:-------------:|:---------:|:-------------------------------------------------------------------------------------------------------|:--------|
+|  `interval`   | `integer` | Number of blocks that should pass between one pruning and the other (default: prune every `10` blocks) | `100`   | 
+| `keep_every`  | `integer` | Keep the state every `nth` block, even if it should have been pruned                                   | `500`   | 
+| `keep_recent` | `integer` | Do not prune this amount of recent states                                                              | `100`   |
 
 ## `telemetry`
-This section allows to configure the telemetry details of Juno. Note that this will have effect only if you add the `"telemetry"` entry to the `modules` field of the [`chain` config](#chain).
+This section allows to configure the telemetry details of Juno. Note that this will have effect only if you add
+the `"telemetry"` entry to the `modules` field of the [`chain` config](#chain).
 
-| Attribute | Type | Description | Example |
-| :-------: | :---: | :--------- | :------ | 
-| `port` | `uint` | Port on which the telemetry server will listen | `8000` | 
+| Attribute |  Type  | Description                                    | Example |
+|:---------:|:------:|:-----------------------------------------------|:--------| 
+|  `port`   | `uint` | Port on which the telemetry server will listen | `8000`  | 
 
 **Note**  
-If the telemetry server is enabled, a new endpoint at the provided port and path `/metrics` will expose [Prometheus](https://prometheus.io/) data.
+If the telemetry server is enabled, a new endpoint at the provided port and path `/metrics` will
+expose [Prometheus](https://prometheus.io/) data.

--- a/cmd/parse/blocks/blocks.go
+++ b/cmd/parse/blocks/blocks.go
@@ -37,8 +37,7 @@ will be replaced with the data downloaded from the node.
 				return err
 			}
 
-			workerCtx := parser.NewContext(parseCtx.EncodingConfig, parseCtx.Node, parseCtx.Database, parseCtx.Logger, parseCtx.Modules)
-			worker := parser.NewWorker(workerCtx, nil, 0)
+			worker := parser.NewWorker(parseCtx, nil, 0)
 
 			// Get the flag values
 			start, _ := cmd.Flags().GetInt64(flagStart)

--- a/cmd/parse/blocks/missing.go
+++ b/cmd/parse/blocks/missing.go
@@ -29,8 +29,7 @@ func newMissingCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 				return err
 			}
 
-			workerCtx := parser.NewContext(parseCtx.EncodingConfig, parseCtx.Node, parseCtx.Database, parseCtx.Logger, parseCtx.Modules)
-			worker := parser.NewWorker(workerCtx, nil, 0)
+			worker := parser.NewWorker(parseCtx, nil, 0)
 
 			dbLastHeight, err := parseCtx.Database.GetLastBlockHeight()
 			if err != nil {

--- a/cmd/parse/transactions/transactions.go
+++ b/cmd/parse/transactions/transactions.go
@@ -32,8 +32,7 @@ You can specify a custom height range by using the %s and %s flags.
 				return err
 			}
 
-			workerCtx := parser.NewContext(parseCtx.EncodingConfig, parseCtx.Node, parseCtx.Database, parseCtx.Logger, parseCtx.Modules)
-			worker := parser.NewWorker(workerCtx, nil, 0)
+			worker := parser.NewWorker(parseCtx, nil, 0)
 
 			// Get the flag values
 			start, _ := cmd.Flags().GetInt64(flagStart)

--- a/cmd/parse/types/setup.go
+++ b/cmd/parse/types/setup.go
@@ -79,7 +79,7 @@ func GetParserContext(cfg config.Config, parseConfig *Config) (*parser.Context, 
 	mods := parseConfig.GetRegistrar().BuildModules(context)
 	registeredModules := modsregistrar.GetModules(mods, cfg.Chain.Modules, logger)
 
-	return parser.NewContext(encodingConfig, node, db, logger, registeredModules), nil
+	return parser.NewContext(cfg, encodingConfig, node, db, logger, registeredModules), nil
 }
 
 // getConfig returns the SDK Config instance as well as if it's sealed or not

--- a/node/config/config_test.go
+++ b/node/config/config_test.go
@@ -69,8 +69,7 @@ config:
 				MaxConnections: 10,
 			},
 			GRPC: &remote.GRPCConfig{
-				Address:  "http://localhost:9090",
-				Insecure: true,
+				Address: "http://localhost:9090",
 			},
 		},
 	}
@@ -86,7 +85,6 @@ config:
         max_connections: 10
     grpc:
         address: http://localhost:9090
-        insecure: true
 `
 	require.Equal(t, strings.TrimLeft(expected, "\n"), string(bz))
 }

--- a/parser/config/config.go
+++ b/parser/config/config.go
@@ -3,14 +3,15 @@ package config
 import "time"
 
 type Config struct {
-	GenesisFilePath string         `yaml:"genesis_file_path,omitempty"`
-	Workers         int64          `yaml:"workers"`
-	StartHeight     int64          `yaml:"start_height"`
-	AvgBlockTime    *time.Duration `yaml:"average_block_time"`
-	ParseNewBlocks  bool           `yaml:"listen_new_blocks"`
-	ParseOldBlocks  bool           `yaml:"parse_old_blocks"`
-	ParseGenesis    bool           `yaml:"parse_genesis"`
-	FastSync        bool           `yaml:"fast_sync,omitempty"`
+	GenesisFilePath     string         `yaml:"genesis_file_path,omitempty"`
+	Workers             int64          `yaml:"workers"`
+	StartHeight         int64          `yaml:"start_height"`
+	AvgBlockTime        *time.Duration `yaml:"average_block_time"`
+	ParseNewBlocks      bool           `yaml:"listen_new_blocks"`
+	ParseOldBlocks      bool           `yaml:"parse_old_blocks"`
+	ParseGenesis        bool           `yaml:"parse_genesis"`
+	FastSync            bool           `yaml:"fast_sync,omitempty"`
+	ReEnqueueWhenFailed bool           `yaml:"re_enqueue_when_failed,omitempty"`
 }
 
 // NewParsingConfig allows to build a new Config instance
@@ -20,16 +21,18 @@ func NewParsingConfig(
 	parseGenesis bool, genesisFilePath string,
 	startHeight int64, fastSync bool,
 	avgBlockTime *time.Duration,
+	reEnqueueWhenFailed bool,
 ) Config {
 	return Config{
-		Workers:         workers,
-		ParseOldBlocks:  parseOldBlocks,
-		ParseNewBlocks:  parseNewBlocks,
-		ParseGenesis:    parseGenesis,
-		GenesisFilePath: genesisFilePath,
-		StartHeight:     startHeight,
-		FastSync:        fastSync,
-		AvgBlockTime:    avgBlockTime,
+		Workers:             workers,
+		ParseOldBlocks:      parseOldBlocks,
+		ParseNewBlocks:      parseNewBlocks,
+		ParseGenesis:        parseGenesis,
+		GenesisFilePath:     genesisFilePath,
+		StartHeight:         startHeight,
+		FastSync:            fastSync,
+		AvgBlockTime:        avgBlockTime,
+		ReEnqueueWhenFailed: reEnqueueWhenFailed,
 	}
 }
 
@@ -45,5 +48,6 @@ func DefaultParsingConfig() Config {
 		1,
 		false,
 		&avgBlockTime,
+		false,
 	)
 }

--- a/parser/context.go
+++ b/parser/context.go
@@ -6,10 +6,12 @@ import (
 	"github.com/forbole/juno/v5/modules"
 	"github.com/forbole/juno/v5/node"
 	"github.com/forbole/juno/v5/types"
+	"github.com/forbole/juno/v5/types/config"
 )
 
 // Context represents the context that is shared among different workers
 type Context struct {
+	Config         config.Config
 	EncodingConfig types.EncodingConfig
 	Node           node.Node
 	Database       database.Database
@@ -19,10 +21,15 @@ type Context struct {
 
 // NewContext builds a new Context instance
 func NewContext(
-	encodingConfig types.EncodingConfig, proxy node.Node, db database.Database,
-	logger logging.Logger, modules []modules.Module,
+	config config.Config,
+	encodingConfig types.EncodingConfig,
+	proxy node.Node,
+	db database.Database,
+	logger logging.Logger,
+	modules []modules.Module,
 ) *Context {
 	return &Context{
+		Config:         config,
 		EncodingConfig: encodingConfig,
 		Node:           proxy,
 		Database:       db,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR implemetns a new field inside the `parsing` configuration object, named `re_enqueue_when_failed`. 

When set to `true`, this will allow re-enqueueing blocks when their parsing (or the parsing of any transactio or message inside them) fail inside anyone of the modules.

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
