### PR TITLE
feat: exponential backoff

### DIFF
--- a/.docs/config.md
+++ b/.docs/config.md
@@ -28,6 +28,7 @@ parsing:
   parse_genesis: true
   fast_sync: true
   re_enqueue_when_failed: false
+  max_retries: 10
 
 database:
   url: postgres://user:password@localhost:5432/juno?sslmode=disable
@@ -106,16 +107,17 @@ node, you need to set the [`node`](#node) type to `local` and then set the follo
 
 ## `parsing`
 
-|        Attribute         |   Type    | Description                                                                                          | Example                                  |
-|:------------------------:|:---------:|:-----------------------------------------------------------------------------------------------------|:-----------------------------------------|
-|        `workers`         | `integer` | Number of workers that will be used to fetch the data and store it inside the database               | `5`                                      |
-|       `fast_sync`        | `boolean` | Whether Juno should use the fast sync abilities of different modules when enabled                    | `false`                                  |
-|   `listen_new_blocks`    | `boolean` | Whether Juno should parse new blocks as soon as they get created                                     | `true`                                   | 
-|     `parse_genesis`      | `boolean` | Whether Juno needs to parse the genesis state or not                                                 | `true`                                   |
-|    `parse_old_blocks`    | `boolean` | Whether Juno should parse old chain blocks or not                                                    | `true`                                   | 
-|      `start_height`      | `integer` | Height at which Juno should start parsing old blocks                                                 | `250000`                                 | 
-|   `genesis_file_path`    | `string`  | Path of the genesis file to be parsed                                                                | `'/bdjuno/.bdjuno/genesis/genesis.json'` |
-| `re_enqueue_when_failed` | `boolean` | Whether blocks should be re-enqueued if the parsing inside various modules fails. (Default: `false`) | `true`                                   |
+|        Attribute         |   Type    | Description                                                                                                                                                                                                                                                               | Example                                  |
+|:------------------------:|:---------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------|
+|        `workers`         | `integer` | Number of workers that will be used to fetch the data and store it inside the database                                                                                                                                                                                    | `5`                                      |
+|       `fast_sync`        | `boolean` | Whether Juno should use the fast sync abilities of different modules when enabled                                                                                                                                                                                         | `false`                                  |
+|   `listen_new_blocks`    | `boolean` | Whether Juno should parse new blocks as soon as they get created                                                                                                                                                                                                          | `true`                                   | 
+|     `parse_genesis`      | `boolean` | Whether Juno needs to parse the genesis state or not                                                                                                                                                                                                                      | `true`                                   |
+|    `parse_old_blocks`    | `boolean` | Whether Juno should parse old chain blocks or not                                                                                                                                                                                                                         | `true`                                   | 
+|      `start_height`      | `integer` | Height at which Juno should start parsing old blocks                                                                                                                                                                                                                      | `250000`                                 | 
+|   `genesis_file_path`    | `string`  | Path of the genesis file to be parsed                                                                                                                                                                                                                                     | `'/bdjuno/.bdjuno/genesis/genesis.json'` |
+| `re_enqueue_when_failed` | `boolean` | Whether blocks should be re-enqueued if the parsing inside various modules fails. (Default: `false`)                                                                                                                                                                      | `true`                                   |
+|      `max_retries`       | `integer` | Number of retries that should be done before giving up on a block parsing. If set to `-1`, the retries will be unlimited. <br/> **Note**: The retry method is going to be based on exponential-backoff, with a wait time of `retryCount * avgBlockTime` per each attempt. | `-1`                                     |
 
 ## `database`
 This section contains all the different configuration related to the PostgreSQL database where Juno will write the data.

--- a/cmd/parse/blocks/blocks.go
+++ b/cmd/parse/blocks/blocks.go
@@ -35,7 +35,7 @@ will be replaced with the data downloaded from the node.
 				return err
 			}
 
-			worker := parser.NewWorker(parseCtx, nil, 0)
+			worker := parser.NewWorker(parseCtx, nil, nil, 0)
 
 			// Get the flag values
 			start, _ := cmd.Flags().GetInt64(flagStart)

--- a/cmd/parse/blocks/missing.go
+++ b/cmd/parse/blocks/missing.go
@@ -29,7 +29,7 @@ func newMissingCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 				return err
 			}
 
-			worker := parser.NewWorker(parseCtx, nil, 0)
+			worker := parser.NewWorker(parseCtx, nil, nil, 0)
 
 			dbLastHeight, err := parseCtx.Database.GetLastBlockHeight()
 			if err != nil {

--- a/cmd/parse/transactions/transactions.go
+++ b/cmd/parse/transactions/transactions.go
@@ -30,7 +30,7 @@ You can specify a custom height range by using the %s and %s flags.
 				return err
 			}
 
-			worker := parser.NewWorker(parseCtx, nil, 0)
+			worker := parser.NewWorker(parseCtx, nil, nil, 0)
 
 			// Get the flag values
 			start, _ := cmd.Flags().GetInt64(flagStart)

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -74,7 +74,7 @@ func startParsing(ctx *parser.Context) error {
 
 	// Create a queue that will collect, aggregate, and export blocks and metadata
 	exportQueue := types.NewQueue(25)
-	retriesCount := types.NewRetriesCount(cfg.MaxRetries)
+	retriesCount := types.NewRetriesCount(cfg.GetMaxRetries())
 
 	// Create workers
 	workers := make([]parser.Worker, cfg.Workers)
@@ -188,7 +188,7 @@ func enqueueNewBlocks(exportQueue types.HeightQueue, ctx *parser.Context) {
 // mustGetLatestHeight tries getting the latest height from the RPC client.
 // If stops searching after the max_retries set inside the config
 func mustGetLatestHeight(ctx *parser.Context) int64 {
-	maxRetries := int(ctx.Config.Parser.MaxRetries)
+	maxRetries := int(ctx.Config.Parser.GetMaxRetries())
 	for retryCount := 0; maxRetries == -1 || retryCount <= maxRetries; retryCount++ {
 		latestBlockHeight, err := ctx.Node.LatestHeight()
 		if err == nil {

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -74,11 +74,12 @@ func startParsing(ctx *parser.Context) error {
 
 	// Create a queue that will collect, aggregate, and export blocks and metadata
 	exportQueue := types.NewQueue(25)
+	retriesCount := types.NewRetriesCount()
 
 	// Create workers
 	workers := make([]parser.Worker, cfg.Workers)
 	for i := range workers {
-		workers[i] = parser.NewWorker(ctx, exportQueue, i)
+		workers[i] = parser.NewWorker(ctx, exportQueue, retriesCount, i)
 	}
 
 	waitGroup.Add(1)

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -74,7 +74,7 @@ func startParsing(ctx *parser.Context) error {
 
 	// Create a queue that will collect, aggregate, and export blocks and metadata
 	exportQueue := types.NewQueue(25)
-	retriesCount := types.NewRetriesCount()
+	retriesCount := types.NewRetriesCount(cfg.MaxRetries)
 
 	// Create workers
 	workers := make([]parser.Worker, cfg.Workers)
@@ -167,47 +167,37 @@ func enqueueMissingBlocks(exportQueue types.HeightQueue, ctx *parser.Context) {
 
 // enqueueNewBlocks enqueues new block heights onto the provided queue.
 func enqueueNewBlocks(exportQueue types.HeightQueue, ctx *parser.Context) {
-	// Get the latest stored block height from the database
-	latestStoredHeight, err := ctx.Database.GetLastBlockHeight()
-	if err != nil {
-		ctx.Logger.Error("failed to get last block height from database", "error", err)
-	}
-
-	// Get the latest block height from the chain
-	latestBlockHeight := mustGetLatestHeight(ctx)
+	currentHeight := mustGetLatestHeight(ctx)
 
 	// Enqueue upcoming heights
 	for {
+		// Get the latest block height from the chain
+		latestBlockHeight := mustGetLatestHeight(ctx)
+
 		// Enqueue all heights from the current height up to the latest height
-		for ; latestStoredHeight <= latestBlockHeight; latestStoredHeight++ {
-			ctx.Logger.Debug("enqueueing new block", "height", latestStoredHeight)
-			exportQueue <- latestStoredHeight
+		for ; currentHeight <= latestBlockHeight; currentHeight++ {
+			ctx.Logger.Debug("enqueueing new block", "height", currentHeight)
+			exportQueue <- currentHeight
 		}
 
 		// Wait for a new block to be produced
 		time.Sleep(config.GetAvgBlockTime())
-
-		// Update the latest stored height and the latest block height
-		latestStoredHeight = latestBlockHeight
-		latestBlockHeight = mustGetLatestHeight(ctx)
 	}
 }
 
 // mustGetLatestHeight tries getting the latest height from the RPC client.
-// If after 50 tries no latest height can be found, it returns 0.
+// If stops searching after the max_retries set inside the config
 func mustGetLatestHeight(ctx *parser.Context) int64 {
-	for retryCount := 0; retryCount < 50; retryCount++ {
+	maxRetries := int(ctx.Config.Parser.MaxRetries)
+	for retryCount := 0; maxRetries == -1 || retryCount <= maxRetries; retryCount++ {
 		latestBlockHeight, err := ctx.Node.LatestHeight()
 		if err == nil {
 			return latestBlockHeight
 		}
 
-		ctx.Logger.Error("failed to get last block from RPCConfig client",
-			"err", err,
-			"retry interval", config.GetAvgBlockTime(),
-			"retry count", retryCount)
+		ctx.Logger.Error("failed to get last block from rpc client", "err", err, "retry count", retryCount)
 
-		time.Sleep(config.GetAvgBlockTime())
+		time.Sleep(config.GetAvgBlockTime() * time.Duration(retryCount))
 	}
 
 	return 0

--- a/parser/config/config.go
+++ b/parser/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	ParseGenesis        bool           `yaml:"parse_genesis"`
 	FastSync            bool           `yaml:"fast_sync,omitempty"`
 	ReEnqueueWhenFailed bool           `yaml:"re_enqueue_when_failed,omitempty"`
+	MaxRetries          int64          `yaml:"max_retries"`
 }
 
 // NewParsingConfig allows to build a new Config instance
@@ -22,6 +23,7 @@ func NewParsingConfig(
 	startHeight int64, fastSync bool,
 	avgBlockTime *time.Duration,
 	reEnqueueWhenFailed bool,
+	maxRetries int64,
 ) Config {
 	return Config{
 		Workers:             workers,
@@ -33,6 +35,7 @@ func NewParsingConfig(
 		FastSync:            fastSync,
 		AvgBlockTime:        avgBlockTime,
 		ReEnqueueWhenFailed: reEnqueueWhenFailed,
+		MaxRetries:          maxRetries,
 	}
 }
 
@@ -49,5 +52,6 @@ func DefaultParsingConfig() Config {
 		false,
 		&avgBlockTime,
 		false,
+		-1,
 	)
 }

--- a/parser/config/config.go
+++ b/parser/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	ParseGenesis        bool           `yaml:"parse_genesis"`
 	FastSync            bool           `yaml:"fast_sync,omitempty"`
 	ReEnqueueWhenFailed bool           `yaml:"re_enqueue_when_failed,omitempty"`
-	MaxRetries          int64          `yaml:"max_retries"`
+	MaxRetries          *int64         `yaml:"max_retries"`
 }
 
 // NewParsingConfig allows to build a new Config instance
@@ -35,7 +35,7 @@ func NewParsingConfig(
 		FastSync:            fastSync,
 		AvgBlockTime:        avgBlockTime,
 		ReEnqueueWhenFailed: reEnqueueWhenFailed,
-		MaxRetries:          maxRetries,
+		MaxRetries:          &maxRetries,
 	}
 }
 
@@ -54,4 +54,11 @@ func DefaultParsingConfig() Config {
 		false,
 		-1,
 	)
+}
+
+func (cfg Config) GetMaxRetries() int64 {
+	if cfg.MaxRetries == nil {
+		return -1
+	}
+	return *cfg.MaxRetries
 }

--- a/parser/worker.go
+++ b/parser/worker.go
@@ -85,7 +85,7 @@ func (w Worker) Start() {
 		err = w.ProcessIfNotExists(i)
 		if err != nil {
 			// Log the error and increment the count
-			w.logger.Debug("re-enqueuing failed block", "height", i, "err", err, "count", w.retriesCounts.Get(i))
+			w.logger.Error("re-enqueuing failed block", "height", i, "err", err, "count", w.retriesCounts.Get(i))
 			w.retriesCounts.Increment(i)
 
 			// Wait for the average block time multiplied by the count and then re-enqueue the height

--- a/types/queue.go
+++ b/types/queue.go
@@ -6,3 +6,24 @@ type HeightQueue chan int64
 func NewQueue(size int) HeightQueue {
 	return make(chan int64, size)
 }
+
+// RetriesCount is a simple type alias for a map of block heights to the number of retries.
+type RetriesCount map[int64]int64
+
+func NewRetriesCount() RetriesCount {
+	return make(map[int64]int64)
+}
+
+func (r RetriesCount) Increment(height int64) {
+	if r == nil {
+		return
+	}
+	r[height]++
+}
+
+func (r RetriesCount) Get(height int64) int64 {
+	if r == nil {
+		return 0
+	}
+	return r[height]
+}

--- a/types/queue.go
+++ b/types/queue.go
@@ -8,22 +8,35 @@ func NewQueue(size int) HeightQueue {
 }
 
 // RetriesCount is a simple type alias for a map of block heights to the number of retries.
-type RetriesCount map[int64]int64
-
-func NewRetriesCount() RetriesCount {
-	return make(map[int64]int64)
+type RetriesCount struct {
+	maxRetries int64
+	count      map[int64]int64
 }
 
-func (r RetriesCount) Increment(height int64) {
+func NewRetriesCount(maxRetries int64) *RetriesCount {
+	return &RetriesCount{
+		maxRetries: maxRetries,
+		count:      make(map[int64]int64),
+	}
+}
+
+func (r *RetriesCount) Increment(height int64) {
 	if r == nil {
 		return
 	}
-	r[height]++
+	r.count[height]++
 }
 
-func (r RetriesCount) Get(height int64) int64 {
+func (r *RetriesCount) HasReachedMax(height int64) bool {
+	if r == nil {
+		return false
+	}
+	return r.maxRetries != -1 && r.count[height] >= r.maxRetries
+}
+
+func (r *RetriesCount) Get(height int64) int64 {
 	if r == nil {
 		return 0
 	}
-	return r[height]
+	return r.count[height]
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR implements the exponential backoff when re-enqueing blocks that have failed the parsing. A new field is added to the `parser` configuration named `max_retries`. This tells how many retries should be made per block, before considering it failed. If set to `-1`, the retries will be unlimited. 

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
