### PR TITLE
fix: check ReparseRange before reading it

### DIFF
--- a/parser/worker.go
+++ b/parser/worker.go
@@ -108,7 +108,7 @@ func (w Worker) ProcessIfNotExists(height int64) error {
 
 	// If the block already exists and the height is not included in the reparse range, skip it
 	if exists {
-		if !w.cfg.Parser.ReparseRange.Includes(height) {
+		if w.cfg.Parser.ReparseRange != nil && !w.cfg.Parser.ReparseRange.Includes(height) {
 			w.logger.Debug("skipping already exported block", "height", height)
 			return nil
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR fixes a bug that cause the crash of the parser when the `ReparseRange` field is not defined.


## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
