### PR TITLE
feat: prometheus monitoring

### DIFF
--- a/cmd/juno/main.go
+++ b/cmd/juno/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/forbole/juno/v5/cmd"
 	"github.com/forbole/juno/v5/modules/registrar"
+	"github.com/forbole/juno/v5/types"
 	cmdtypes "github.com/forbole/juno/v5/types/cmd"
 	parsecmdtypes "github.com/forbole/juno/v5/types/cmd/parse"
 )
@@ -13,6 +14,9 @@ func main() {
 	// JunoConfig the runner
 	config := cmdtypes.NewConfig("juno").
 		WithParseConfig(parsecmdtypes.NewConfig().
+			WithEncodingConfigBuilder(func() types.EncodingConfig {
+				return types.EncodingConfig{}
+			}).
 			WithRegistrar(registrar.NewDefaultRegistrar()),
 		)
 

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -62,7 +62,11 @@ func startParsing(ctx *parser.Context) error {
 	monitoringCfg := ctx.Config.Monitoring
 	if monitoringCfg.Enabled {
 		http.Handle("/metrics", promhttp.Handler())
-		go http.ListenAndServe(fmt.Sprintf(":%d", monitoringCfg.Port), nil)
+		server := &http.Server{
+			Addr:              fmt.Sprintf(":%d", monitoringCfg.Port),
+			ReadHeaderTimeout: 3 * time.Second,
+		}
+		go server.ListenAndServe()
 	}
 
 	// Start periodic operations

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -1,6 +1,8 @@
 package start
 
 import (
+	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -16,6 +18,7 @@ import (
 	"github.com/forbole/juno/v5/types"
 	cmdtypes "github.com/forbole/juno/v5/types/cmd"
 	"github.com/forbole/juno/v5/utils"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -54,6 +57,13 @@ func startParsing(ctx *parser.Context) error {
 	// Get the config
 	cfg := ctx.Config.Parser
 	logging.StartHeight.Add(float64(cfg.StartHeight))
+
+	// Start the prometheus monitoring
+	monitoringCfg := ctx.Config.Monitoring
+	if monitoringCfg.Enabled {
+		http.Handle("/metrics", promhttp.Handler())
+		go http.ListenAndServe(fmt.Sprintf(":%d", monitoringCfg.Port), nil)
+	}
 
 	// Start periodic operations
 	scheduler := gocron.NewScheduler(time.UTC)

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -135,6 +135,7 @@ func enqueueMissingBlocks(exportQueue types.HeightQueue, ctx *parser.Context) {
 	lastDbBlockHeight, err := ctx.Database.GetLastBlockHeight()
 	if err != nil {
 		ctx.Logger.Error("failed to get last block height from database", "error", err)
+		logging.SignalDBOperationError()
 	}
 
 	// Get the start height, default to the config's height
@@ -207,6 +208,7 @@ func mustGetLatestHeight(ctx *parser.Context) int64 {
 		}
 
 		ctx.Logger.Error("failed to get last block from rpc client", "err", err, "retry count", retryCount)
+		logging.SignalRPCRequestError()
 
 		time.Sleep(ctx.Config.GetAvgBlockTime() * time.Duration(retryCount))
 	}

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -1,8 +1,6 @@
 package start
 
 import (
-	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -18,7 +16,6 @@ import (
 	"github.com/forbole/juno/v5/types"
 	cmdtypes "github.com/forbole/juno/v5/types/cmd"
 	"github.com/forbole/juno/v5/utils"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -61,12 +58,7 @@ func startParsing(ctx *parser.Context) error {
 	// Start the prometheus monitoring
 	monitoringCfg := ctx.Config.Monitoring
 	if monitoringCfg.Enabled {
-		http.Handle("/metrics", promhttp.Handler())
-		server := &http.Server{
-			Addr:              fmt.Sprintf(":%d", monitoringCfg.Port),
-			ReadHeaderTimeout: 3 * time.Second,
-		}
-		go server.ListenAndServe()
+		ctx.Prometheus.Start()
 	}
 
 	// Start periodic operations
@@ -234,5 +226,6 @@ func trapSignal(ctx *parser.Context) {
 		defer ctx.Node.Stop()
 		defer ctx.Database.Close()
 		defer waitGroup.Done()
+		defer ctx.Prometheus.Stop()
 	}()
 }

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -56,8 +56,7 @@ func startParsing(ctx *parser.Context) error {
 	logging.StartHeight.Add(float64(cfg.StartHeight))
 
 	// Start the prometheus monitoring
-	monitoringCfg := ctx.Config.Monitoring
-	if monitoringCfg.Enabled {
+	if ctx.Prometheus != nil {
 		ctx.Prometheus.Start()
 	}
 
@@ -226,6 +225,8 @@ func trapSignal(ctx *parser.Context) {
 		defer ctx.Node.Stop()
 		defer ctx.Database.Close()
 		defer waitGroup.Done()
-		defer ctx.Prometheus.Stop()
+		if ctx.Prometheus != nil {
+			defer ctx.Prometheus.Stop()
+		}
 	}()
 }

--- a/logging/prometheus.go
+++ b/logging/prometheus.go
@@ -47,15 +47,13 @@ var DbBlockCount = prometheus.NewGaugeVec(
 	[]string{"total_blocks_in_db"},
 )
 
-// RPC Liveness
-var RpcRequestErrors = prometheus.NewCounter(
+var RPCRequestErrors = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Name: "juno_rpc_errors_total",
 		Help: "Total number of errors occurred during RPC requests",
 	},
 )
 
-// Database Liveness
 var DbOperationErrors = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Name: "juno_db_errors_total",
@@ -63,8 +61,7 @@ var DbOperationErrors = prometheus.NewCounter(
 	},
 )
 
-// Block parsing
-var FetchBlockErrorCount = prometheus.NewCounterVec(
+var ProcessBlockErrorCount = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "juno_block_errors_total",
 		Help: "Total number of errors per block",
@@ -83,7 +80,7 @@ var DbLatestHeight = prometheus.NewGaugeVec(
 
 // SignalRPCRequestError signal that a new rpc request error occurred
 func SignalRPCRequestError() {
-	RpcRequestErrors.Inc()
+	RPCRequestErrors.Inc()
 }
 
 // SignalDBOperationError signal that a new error occurred while interacting
@@ -95,7 +92,7 @@ func SignalDBOperationError() {
 // SignalBlockError increments the error counter for the given block
 func SignalBlockError(blockHeight int64) {
 	blockStr := fmt.Sprintf("%d", blockHeight)
-	FetchBlockErrorCount.WithLabelValues(blockStr).Inc()
+	ProcessBlockErrorCount.WithLabelValues(blockStr).Inc()
 	prometheus.MustRegister()
 }
 
@@ -106,7 +103,7 @@ func init() {
 	prometheus.MustRegister(ErrorCount)
 	prometheus.MustRegister(DbBlockCount)
 	prometheus.MustRegister(DbLatestHeight)
-	prometheus.MustRegister(RpcRequestErrors)
+	prometheus.MustRegister(RPCRequestErrors)
 	prometheus.MustRegister(DbOperationErrors)
-	prometheus.MustRegister(FetchBlockErrorCount)
+	prometheus.MustRegister(ProcessBlockErrorCount)
 }

--- a/parser/context.go
+++ b/parser/context.go
@@ -5,6 +5,7 @@ import (
 	"github.com/forbole/juno/v5/logging"
 	"github.com/forbole/juno/v5/modules"
 	"github.com/forbole/juno/v5/node"
+	"github.com/forbole/juno/v5/prometheus"
 	"github.com/forbole/juno/v5/types"
 	"github.com/forbole/juno/v5/types/config"
 )
@@ -17,6 +18,7 @@ type Context struct {
 	Database       database.Database
 	Logger         logging.Logger
 	Modules        []modules.Module
+	Prometheus     *prometheus.Server
 }
 
 // NewContext builds a new Context instance
@@ -35,5 +37,6 @@ func NewContext(
 		Database:       db,
 		Modules:        modules,
 		Logger:         logger,
+		Prometheus:     prometheus.NewServer(config.Monitoring.Port),
 	}
 }

--- a/parser/context.go
+++ b/parser/context.go
@@ -37,6 +37,6 @@ func NewContext(
 		Database:       db,
 		Modules:        modules,
 		Logger:         logger,
-		Prometheus:     prometheus.NewServer(config.Monitoring.Port),
+		Prometheus:     prometheus.NewServer(config.Monitoring),
 	}
 }

--- a/parser/worker.go
+++ b/parser/worker.go
@@ -78,6 +78,9 @@ func (w Worker) Start() {
 		err = w.ProcessIfNotExists(i.Height)
 		if err != nil {
 			go func() {
+				// Signal that an error occurred while processing this block
+				logging.SignalBlockError(i.Height)
+
 				// Build the block with the updated retry count and log the error
 				newBlock := i.IncrementRetryCount()
 				w.logger.Debug("re-enqueuing failed block", "height", i.Height, "err", err, "count", newBlock.RetryCount)

--- a/prometheus/server.go
+++ b/prometheus/server.go
@@ -1,0 +1,44 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type Server struct {
+	port   int16
+	server *http.Server
+}
+
+// NewServer returns a new prometheus server instance
+func NewServer(port int16) *Server {
+	return &Server{
+		port: port,
+	}
+}
+
+// Start starts the prometheus server
+func (s *Server) Start() {
+	// Server already started
+	if s.server != nil {
+		return
+	}
+
+	http.Handle("/metrics", promhttp.Handler())
+	s.server = &http.Server{
+		Addr:              fmt.Sprintf(":%d", s.port),
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	go s.server.ListenAndServe()
+}
+
+// Stop stops the prometheus server
+func (s *Server) Stop() {
+	if s.server != nil {
+		s.server.Close()
+		s.server = nil
+	}
+}

--- a/prometheus/server.go
+++ b/prometheus/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/forbole/juno/v5/types/config"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -14,9 +15,13 @@ type Server struct {
 }
 
 // NewServer returns a new prometheus server instance
-func NewServer(port int16) *Server {
+func NewServer(monitoringConfig *config.MonitoringConfig) *Server {
+	if monitoringConfig == nil || !monitoringConfig.Enabled {
+		return nil
+	}
+
 	return &Server{
-		port: port,
+		port: monitoringConfig.Port,
 	}
 }
 

--- a/types/config/config.go
+++ b/types/config/config.go
@@ -15,11 +15,12 @@ import (
 type Config struct {
 	bytes []byte
 
-	Chain    ChainConfig           `yaml:"chain"`
-	Node     nodeconfig.Config     `yaml:"node"`
-	Parser   parserconfig.Config   `yaml:"parsing"`
-	Database databaseconfig.Config `yaml:"database"`
-	Logging  loggingconfig.Config  `yaml:"logging"`
+	Chain      ChainConfig           `yaml:"chain"`
+	Node       nodeconfig.Config     `yaml:"node"`
+	Parser     parserconfig.Config   `yaml:"parsing"`
+	Database   databaseconfig.Config `yaml:"database"`
+	Logging    loggingconfig.Config  `yaml:"logging"`
+	Monitoring MonitoringConfig      `yaml:"monitoring"`
 }
 
 // NewConfig builds a new Config instance
@@ -27,13 +28,15 @@ func NewConfig(
 	nodeCfg nodeconfig.Config,
 	chainCfg ChainConfig, dbConfig databaseconfig.Config,
 	parserConfig parserconfig.Config, loggingConfig loggingconfig.Config,
+	monitoringConfig MonitoringConfig,
 ) Config {
 	return Config{
-		Node:     nodeCfg,
-		Chain:    chainCfg,
-		Database: dbConfig,
-		Parser:   parserConfig,
-		Logging:  loggingConfig,
+		Node:       nodeCfg,
+		Chain:      chainCfg,
+		Database:   dbConfig,
+		Parser:     parserConfig,
+		Logging:    loggingConfig,
+		Monitoring: monitoringConfig,
 	}
 }
 
@@ -42,6 +45,7 @@ func DefaultConfig() Config {
 		nodeconfig.DefaultConfig(),
 		DefaultChainConfig(), databaseconfig.DefaultDatabaseConfig(),
 		parserconfig.DefaultParsingConfig(), loggingconfig.DefaultLoggingConfig(),
+		DefaultMonitoringConfig(),
 	)
 
 	bz, err := yaml.Marshal(cfg)
@@ -85,4 +89,27 @@ func (cfg ChainConfig) IsModuleEnabled(moduleName string) bool {
 	}
 
 	return false
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+type MonitoringConfig struct {
+	Enabled bool  `yaml:"enabled"`
+	Port    int16 `yaml:"port"`
+}
+
+// DefaultMonitoringConfig returns the default instance of MonitoringConfig
+func DefaultMonitoringConfig() MonitoringConfig {
+	return MonitoringConfig{
+		Enabled: true,
+		Port:    2112,
+	}
+}
+
+// NewMonitoringConfig returns a new instance of MonitoringConfig
+func NewMonitoringConfig(enabled bool, port int16) MonitoringConfig {
+	return MonitoringConfig{
+		Enabled: enabled,
+		Port:    port,
+	}
 }

--- a/types/config/config.go
+++ b/types/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	Parser     parserconfig.Config   `yaml:"parsing"`
 	Database   databaseconfig.Config `yaml:"database"`
 	Logging    loggingconfig.Config  `yaml:"logging"`
-	Monitoring MonitoringConfig      `yaml:"monitoring"`
+	Monitoring *MonitoringConfig     `yaml:"monitoring"`
 }
 
 // NewConfig builds a new Config instance
@@ -28,7 +28,7 @@ func NewConfig(
 	nodeCfg nodeconfig.Config,
 	chainCfg ChainConfig, dbConfig databaseconfig.Config,
 	parserConfig parserconfig.Config, loggingConfig loggingconfig.Config,
-	monitoringConfig MonitoringConfig,
+	monitoringConfig *MonitoringConfig,
 ) Config {
 	return Config{
 		Node:       nodeCfg,
@@ -99,8 +99,8 @@ type MonitoringConfig struct {
 }
 
 // DefaultMonitoringConfig returns the default instance of MonitoringConfig
-func DefaultMonitoringConfig() MonitoringConfig {
-	return MonitoringConfig{
+func DefaultMonitoringConfig() *MonitoringConfig {
+	return &MonitoringConfig{
 		Enabled: true,
 		Port:    2112,
 	}


### PR DESCRIPTION
## Description
This PR allows to expose a `/metrics` endpoint that can be used to monitor a parser trough [prometheus](https://prometheus.io/).  

The monitoring can be enabled trough the config file by adding a new `monitoring` section like this:
```yaml
monitoring:
  enabled: true
  port: 2112
```

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
