### PR TITLE
refactor: optimzed database reads

### DIFF
--- a/logging/prometheus.go
+++ b/logging/prometheus.go
@@ -39,14 +39,6 @@ var ErrorCount = prometheus.NewCounter(
 	},
 )
 
-var DBBlockCount = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Name: "juno_db_total_blocks",
-		Help: "Total number of blocks in database.",
-	},
-	[]string{"total_blocks_in_db"},
-)
-
 var RPCRequestErrors = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Name: "juno_rpc_errors_total",
@@ -101,7 +93,6 @@ func init() {
 	prometheus.MustRegister(WorkerCount)
 	prometheus.MustRegister(WorkerHeight)
 	prometheus.MustRegister(ErrorCount)
-	prometheus.MustRegister(DBBlockCount)
 	prometheus.MustRegister(DBLatestHeight)
 	prometheus.MustRegister(RPCRequestErrors)
 	prometheus.MustRegister(DBOperationErrors)

--- a/parser/worker.go
+++ b/parser/worker.go
@@ -372,11 +372,13 @@ func (w Worker) ExportTxs(txs []*types.Tx) error {
 		}
 	}
 
-	dbLatestHeight, err := w.db.GetLastBlockHeight()
-	if err != nil {
-		return err
+	if w.cfg.Monitoring.Enabled {
+		dbLatestHeight, err := w.db.GetLastBlockHeight()
+		if err != nil {
+			return err
+		}
+		logging.DBLatestHeight.WithLabelValues("db_latest_height").Set(float64(dbLatestHeight))
 	}
-	logging.DBLatestHeight.WithLabelValues("db_latest_height").Set(float64(dbLatestHeight))
 
 	return nil
 }

--- a/parser/worker.go
+++ b/parser/worker.go
@@ -197,7 +197,7 @@ func (w Worker) HandleGenesis(genesisDoc *tmtypes.GenesisDoc, appState map[strin
 // consensus public key. An error is returned if the public key cannot be Bech32
 // encoded or if the DB write fails.
 func (w Worker) SaveValidators(vals []*tmtypes.Validator) error {
-	var validators = make([]*types.Validator, len(vals))
+	validators := make([]*types.Validator, len(vals))
 	for index, val := range vals {
 		consAddr := sdk.NewConsAddress(val.Address).String()
 
@@ -371,9 +371,6 @@ func (w Worker) ExportTxs(txs []*types.Tx) error {
 			}
 		}
 	}
-
-	totalBlocks := w.db.GetTotalBlocks()
-	logging.DBBlockCount.WithLabelValues("total_blocks_in_db").Set(float64(totalBlocks))
 
 	dbLatestHeight, err := w.db.GetLastBlockHeight()
 	if err != nil {


### PR DESCRIPTION
## Description
This PR removes the monitoring of the total blocks that where indexed in order to reduce the CPU usage by the database. 
Additionally ensure that all the metrics that are computed by reading from the database are updated only if the monitoring is enabled. 

CPU Usage difference:
![cpu-usage](https://github.com/user-attachments/assets/adbee021-1d88-4a50-a148-1037be0b5b00)


Closes: API-85

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
