### PR TITLE
feat: ignore the first tx (connect oracle extension tx)

### DIFF
--- a/node/config/config_test.go
+++ b/node/config/config_test.go
@@ -24,7 +24,7 @@ config:
     insecure: true
     address: "http://localhost:9090"
   
-  ignore_connect_vote_extension_tx: false
+  ignore_connect_vote_extension_tx: true
 `
 
 	var config nodeconfig.Config
@@ -45,6 +45,7 @@ func TestConfig_MarshalYAML(t *testing.T) {
 			GRPC: &remote.GRPCConfig{
 				Address: "http://localhost:9090",
 			},
+			IgnoreConnectVoteExtensionTx: true,
 		},
 	}
 	bz, err := yaml.Marshal(&config)
@@ -59,7 +60,7 @@ config:
         max_connections: 10
     grpc:
         address: http://localhost:9090
-    ignore_connect_vote_extension_tx: false
+    ignore_connect_vote_extension_tx: true
 `
 	require.Equal(t, strings.TrimLeft(expected, "\n"), string(bz))
 }

--- a/node/config/config_test.go
+++ b/node/config/config_test.go
@@ -23,6 +23,8 @@ config:
   grpc:
     insecure: true
     address: "http://localhost:9090"
+  
+  ignore_connect_vote_extension_tx: false
 `
 
 	var config nodeconfig.Config
@@ -57,6 +59,7 @@ config:
         max_connections: 10
     grpc:
         address: http://localhost:9090
+    ignore_connect_vote_extension_tx: false
 `
 	require.Equal(t, strings.TrimLeft(expected, "\n"), string(bz))
 }

--- a/node/remote/config.go
+++ b/node/remote/config.go
@@ -6,19 +6,21 @@ import (
 
 // Details represents a node details for a remote node
 type Details struct {
-	RPC  *RPCConfig  `yaml:"rpc"`
-	GRPC *GRPCConfig `yaml:"grpc"`
+	RPC                          *RPCConfig  `yaml:"rpc"`
+	GRPC                         *GRPCConfig `yaml:"grpc"`
+	IgnoreConnectVoteExtensionTx bool        `yaml:"ignore_connect_vote_extension_tx"` // ignore tx[0] for the chains that are using Skip Oracle
 }
 
-func NewDetails(rpc *RPCConfig, grpc *GRPCConfig) *Details {
+func NewDetails(rpc *RPCConfig, grpc *GRPCConfig, ignoreConnectVoteExtensionTx bool) *Details {
 	return &Details{
-		RPC:  rpc,
-		GRPC: grpc,
+		RPC:                          rpc,
+		GRPC:                         grpc,
+		IgnoreConnectVoteExtensionTx: ignoreConnectVoteExtensionTx,
 	}
 }
 
 func DefaultDetails() *Details {
-	return NewDetails(DefaultRPCConfig(), DefaultGrpcConfig())
+	return NewDetails(DefaultRPCConfig(), DefaultGrpcConfig(), false)
 }
 
 // Validate implements node.Details


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
@hallazzang found that the skip oracle injects their oracle data at tx[0] always:
https://github.com/skip-mev/connect/blob/7a115b15fd218eae84e42195941c5a3b0761d2eb/abci/proposals/proposals.go#L222

We need to skip this tx for milkyway chain

## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
